### PR TITLE
add julie Configuration entry

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -34,6 +34,7 @@ toc::[]
 * https://github.com/devshawn/kafka-gitops[kafka-gitops]: Manage Apache Kafka topics and generate ACLs through a desired state file. https://github.com/devshawn/kafka-gitops/blob/master/LICENSE[Apache License 2.0]
 * https://github.com/streamthoughts/kafka-specs[Kafka Specs]: Tool to ease and automate Apache Kafka cluster configuration management. https://github.com/streamthoughts/kafka-specs/blob/master/LICENSE[Apache License 2.0]
 * https://kattlo.github.io/[kattlo]: Kattlo gives a way to manage topics, ACLs, users, schemas, ksqlDB, employing a evolutionary configuration. Easy to understand, easy to write and easy to apply. https://github.com/kattlo/kattlo-cli/blob/main/LICENSE[Apache License 2.0]
+* https://github.com/kafka-ops/julie[julie]: An operational manager for Apache Kafka (Automation, GitOps, SelfService) https://github.com/kafka-ops/julie/blob/master/LICENSE[MIT License]
 
 == Examples
 


### PR DESCRIPTION
Add entry for Julie An operational manager for Apache Kafka (Automation, GitOps, SelfService)
NOTE: This project was formally known as Kafka Topology Builder, old versions of this project can still be found under that name.  https://github.com/kafka-ops/julie